### PR TITLE
Fix AndroidX build issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,13 @@ Este proyecto es un ejemplo mínimo de una aplicación Android que muestra
 
 1. Asegúrate de tener [Android Studio](https://developer.android.com/studio) o Gradle instalado.
 2. Si el archivo `gradle/wrapper/gradle-wrapper.jar` no está presente, ejecuta `gradle wrapper` para generarlo.
-3. Luego puedes compilar el proyecto con:
+3. Este proyecto usa AndroidX. Si es la primera vez que lo clonas, crea el archivo `gradle.properties` con:
+
+   ```
+   android.useAndroidX=true
+   android.enableJetifier=true
+   ```
+4. Luego puedes compilar el proyecto con:
 
 ```bash
 ./gradlew assembleDebug

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+android.useAndroidX=true
+android.enableJetifier=true


### PR DESCRIPTION
## Summary
- add gradle.properties enabling AndroidX and Jetifier
- document AndroidX settings in README

## Testing
- `./gradlew tasks` *(fails: Unable to access jarfile gradle-wrapper.jar)*
- `gradle wrapper` *(fails: Could not resolve dependencies due to network access restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6856f8e9cfb0832486a0038b5d295db9