### PR TITLE
Enhance task app with categories and due dates

### DIFF
--- a/app/src/main/java/com/example/holamundo/todo/AppDatabase.java
+++ b/app/src/main/java/com/example/holamundo/todo/AppDatabase.java
@@ -9,7 +9,7 @@ import androidx.room.RoomDatabase;
 /**
  * Base de datos Room que almacena las tareas.
  */
-@Database(entities = {Task.class}, version = 2)
+@Database(entities = {Task.class}, version = 3)
 public abstract class AppDatabase extends RoomDatabase {
     public abstract TaskDao taskDao();
 

--- a/app/src/main/java/com/example/holamundo/todo/Task.java
+++ b/app/src/main/java/com/example/holamundo/todo/Task.java
@@ -16,6 +16,15 @@ public class Task {
     /** Descripción detallada de la tarea. */
     public String description;
 
+    /** Categoría de la tarea (p.ej. Trabajo, Personal). */
+    public String category;
+
+    /** Prioridad 0=baja,1=media,2=alta. */
+    public int priority;
+
+    /** Fecha límite en milisegundos. */
+    public Long dueDate;
+
     /** Marca temporal de creación en milisegundos. */
     public long createdAt;
 

--- a/app/src/main/java/com/example/holamundo/todo/TaskAdapter.java
+++ b/app/src/main/java/com/example/holamundo/todo/TaskAdapter.java
@@ -56,7 +56,12 @@ public class TaskAdapter extends RecyclerView.Adapter<TaskAdapter.TaskViewHolder
                 return o.completed == n.completed &&
                         o.title.equals(n.title) &&
                         ((o.description == null && n.description == null) ||
-                         (o.description != null && o.description.equals(n.description)));
+                         (o.description != null && o.description.equals(n.description))) &&
+                        ((o.category == null && n.category == null) ||
+                         (o.category != null && o.category.equals(n.category))) &&
+                        o.priority == n.priority &&
+                        ((o.dueDate == null && n.dueDate == null) ||
+                         (o.dueDate != null && o.dueDate.equals(n.dueDate)));
             }
         });
         diff.dispatchUpdatesTo(this);
@@ -95,6 +100,8 @@ public class TaskAdapter extends RecyclerView.Adapter<TaskAdapter.TaskViewHolder
         final CheckBox checkCompleted;
         final TextView textTitle;
         final TextView textDescription;
+        final TextView textDueDate;
+        final TextView textCategory;
         final ImageButton buttonEdit;
         final ImageButton buttonDelete;
 
@@ -103,6 +110,8 @@ public class TaskAdapter extends RecyclerView.Adapter<TaskAdapter.TaskViewHolder
             checkCompleted = itemView.findViewById(R.id.check_completed);
             textTitle = itemView.findViewById(R.id.text_title);
             textDescription = itemView.findViewById(R.id.text_description);
+            textDueDate = itemView.findViewById(R.id.text_due_date);
+            textCategory = itemView.findViewById(R.id.text_category);
             buttonEdit = itemView.findViewById(R.id.button_edit);
             buttonDelete = itemView.findViewById(R.id.button_delete);
         }
@@ -112,6 +121,13 @@ public class TaskAdapter extends RecyclerView.Adapter<TaskAdapter.TaskViewHolder
             checkCompleted.setChecked(task.completed);
             textTitle.setText(task.title);
             textDescription.setText(task.description);
+            if (task.dueDate != null && task.dueDate > 0) {
+                java.text.DateFormat df = java.text.DateFormat.getDateInstance();
+                textDueDate.setText(df.format(new java.util.Date(task.dueDate)));
+            } else {
+                textDueDate.setText("");
+            }
+            textCategory.setText(task.category);
             checkCompleted.setOnCheckedChangeListener((buttonView, isChecked) -> {
                 if (listener != null) listener.onToggle(task, isChecked);
             });

--- a/app/src/main/java/com/example/holamundo/todo/TaskListActivity.java
+++ b/app/src/main/java/com/example/holamundo/todo/TaskListActivity.java
@@ -57,6 +57,21 @@ public class TaskListActivity extends AppCompatActivity implements TaskAdapter.T
             public void onNothingSelected(AdapterView<?> parent) { }
         });
 
+        Spinner spinnerCategoryFilter = findViewById(R.id.spinner_category_filter);
+        ArrayAdapter<CharSequence> catAdapter = ArrayAdapter.createFromResource(this,
+                R.array.categories, android.R.layout.simple_spinner_item);
+        catAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        spinnerCategoryFilter.setAdapter(catAdapter);
+        spinnerCategoryFilter.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+                loadTasks();
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView<?> parent) { }
+        });
+
         RecyclerView recyclerView = findViewById(R.id.recycler_tasks);
         recyclerView.setLayoutManager(new LinearLayoutManager(this));
         recyclerView.setAdapter(adapter);
@@ -94,7 +109,21 @@ public class TaskListActivity extends AppCompatActivity implements TaskAdapter.T
     }
 
     private void loadTasks() {
-        TaskRepository.TasksCallback callback = tasks -> runOnUiThread(() -> adapter.setTasks(tasks));
+        Spinner catSpinner = findViewById(R.id.spinner_category_filter);
+        String selectedCat = (String) catSpinner.getSelectedItem();
+        TaskRepository.TasksCallback callback = tasks -> {
+            if (selectedCat != null && !selectedCat.isEmpty()) {
+                if (!selectedCat.equalsIgnoreCase("All")) {
+                    java.util.List<Task> filtered = new java.util.ArrayList<>();
+                    for (Task t : tasks) {
+                        if (selectedCat.equals(t.category)) filtered.add(t);
+                    }
+                    tasks = filtered;
+                }
+            }
+            java.util.List<Task> finalList = tasks;
+            runOnUiThread(() -> adapter.setTasks(finalList));
+        };
         switch (currentFilter) {
             case "DONE":
                 repository.getCompleted(callback);
@@ -114,6 +143,19 @@ public class TaskListActivity extends AppCompatActivity implements TaskAdapter.T
         View dialogView = inflater.inflate(R.layout.dialog_task, null);
         EditText editTitle = dialogView.findViewById(R.id.edit_title);
         EditText editDesc = dialogView.findViewById(R.id.edit_description);
+        Spinner spinnerPriority = dialogView.findViewById(R.id.spinner_priority);
+        Spinner spinnerCategory = dialogView.findViewById(R.id.spinner_category);
+        EditText editDue = dialogView.findViewById(R.id.edit_due_date);
+
+        ArrayAdapter<CharSequence> pAdapter = ArrayAdapter.createFromResource(this,
+                R.array.priorities, android.R.layout.simple_spinner_item);
+        pAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        spinnerPriority.setAdapter(pAdapter);
+
+        ArrayAdapter<CharSequence> cAdapter = ArrayAdapter.createFromResource(this,
+                R.array.categories, android.R.layout.simple_spinner_item);
+        cAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        spinnerCategory.setAdapter(cAdapter);
 
         new AlertDialog.Builder(this)
                 .setTitle(R.string.add_task)
@@ -129,6 +171,15 @@ public class TaskListActivity extends AppCompatActivity implements TaskAdapter.T
                         Task task = new Task();
                         task.title = title;
                         task.description = desc;
+                        task.priority = spinnerPriority.getSelectedItemPosition();
+                        task.category = spinnerCategory.getSelectedItem().toString();
+                        String dueText = editDue.getText().toString().trim();
+                        if (!dueText.isEmpty()) {
+                            try {
+                                java.text.DateFormat df = java.text.DateFormat.getDateInstance();
+                                task.dueDate = df.parse(dueText).getTime();
+                            } catch (Exception ignore) {}
+                        }
                         repository.insert(task, this::loadTasks);
                     }
                 })
@@ -143,6 +194,26 @@ public class TaskListActivity extends AppCompatActivity implements TaskAdapter.T
         View dialogView = inflater.inflate(R.layout.dialog_task, null);
         EditText editTitle = dialogView.findViewById(R.id.edit_title);
         EditText editDesc = dialogView.findViewById(R.id.edit_description);
+        Spinner spinnerPriority = dialogView.findViewById(R.id.spinner_priority);
+        Spinner spinnerCategory = dialogView.findViewById(R.id.spinner_category);
+        EditText editDue = dialogView.findViewById(R.id.edit_due_date);
+
+        ArrayAdapter<CharSequence> pAdapter = ArrayAdapter.createFromResource(this,
+                R.array.priorities, android.R.layout.simple_spinner_item);
+        pAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        spinnerPriority.setAdapter(pAdapter);
+        spinnerPriority.setSelection(task.priority);
+
+        ArrayAdapter<CharSequence> cAdapter = ArrayAdapter.createFromResource(this,
+                R.array.categories, android.R.layout.simple_spinner_item);
+        cAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        spinnerCategory.setAdapter(cAdapter);
+        int cIndex = java.util.Arrays.asList(getResources().getStringArray(R.array.categories)).indexOf(task.category);
+        if (cIndex >= 0) spinnerCategory.setSelection(cIndex);
+        if (task.dueDate != null && task.dueDate > 0) {
+            java.text.DateFormat df = java.text.DateFormat.getDateInstance();
+            editDue.setText(df.format(new java.util.Date(task.dueDate)));
+        }
         editTitle.setText(task.title);
         editDesc.setText(task.description);
 
@@ -158,6 +229,17 @@ public class TaskListActivity extends AppCompatActivity implements TaskAdapter.T
                     } else {
                         task.title = title;
                         task.description = desc;
+                        task.priority = spinnerPriority.getSelectedItemPosition();
+                        task.category = spinnerCategory.getSelectedItem().toString();
+                        String dueText = editDue.getText().toString().trim();
+                        if (!dueText.isEmpty()) {
+                            try {
+                                java.text.DateFormat df = java.text.DateFormat.getDateInstance();
+                                task.dueDate = df.parse(dueText).getTime();
+                            } catch (Exception ignore) {}
+                        } else {
+                            task.dueDate = null;
+                        }
                         repository.update(task);
                         loadTasks();
                     }

--- a/app/src/main/res/layout/activity_task_list.xml
+++ b/app/src/main/res/layout/activity_task_list.xml
@@ -9,12 +9,19 @@
         android:layout_height="match_parent"
         android:orientation="vertical">
 
-        <Spinner
-            android:id="@+id/spinner_filter"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="end"
-            android:layout_margin="8dp" />
+          <Spinner
+              android:id="@+id/spinner_filter"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:layout_gravity="end"
+              android:layout_margin="8dp" />
+
+          <Spinner
+              android:id="@+id/spinner_category_filter"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:layout_gravity="end"
+              android:layout_margin="8dp" />
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/recycler_tasks"

--- a/app/src/main/res/layout/dialog_task.xml
+++ b/app/src/main/res/layout/dialog_task.xml
@@ -16,4 +16,23 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:hint="@string/description_hint" />
+
+    <Spinner
+        android:id="@+id/spinner_priority"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:prompt="@string/priority" />
+
+    <Spinner
+        android:id="@+id/spinner_category"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:prompt="@string/category" />
+
+    <EditText
+        android:id="@+id/edit_due_date"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/due_date"
+        android:inputType="date" />
 </LinearLayout>

--- a/app/src/main/res/layout/item_task.xml
+++ b/app/src/main/res/layout/item_task.xml
@@ -30,12 +30,24 @@
                 android:textStyle="bold"
                 android:textSize="18sp" />
 
-            <TextView
-                android:id="@+id/text_description"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:textColor="?android:attr/textColorSecondary" />
-        </LinearLayout>
+              <TextView
+                  android:id="@+id/text_description"
+                  android:layout_width="match_parent"
+                  android:layout_height="wrap_content"
+                  android:textColor="?android:attr/textColorSecondary" />
+
+              <TextView
+                  android:id="@+id/text_due_date"
+                  android:layout_width="match_parent"
+                  android:layout_height="wrap_content"
+                  android:textColor="?android:attr/textColorSecondary" />
+
+              <TextView
+                  android:id="@+id/text_category"
+                  android:layout_width="match_parent"
+                  android:layout_height="wrap_content"
+                  android:textColor="?android:attr/textColorSecondary" />
+          </LinearLayout>
 
         <ImageButton
             android:id="@+id/button_edit"

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -3,6 +3,17 @@
         <item>@string/filter_all</item>
         <item>@string/filter_completed</item>
         <item>@string/filter_pending</item>
+</string-array>
+    <string-array name="priorities">
+        <item>Low</item>
+        <item>Medium</item>
+        <item>High</item>
+    </string-array>
+    <string-array name="categories">
+        <item>All</item>
+        <item>Work</item>
+        <item>Personal</item>
+        <item>Other</item>
     </string-array>
     <string-array name="filters_values">
         <item>ALL</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,4 +12,7 @@
     <string name="filter_completed">Completed</string>
     <string name="filter_pending">Pending</string>
     <string name="title_tasks">Tasks</string>
+    <string name="category">Category</string>
+    <string name="priority">Priority</string>
+    <string name="due_date">Due date</string>
 </resources>


### PR DESCRIPTION
## Summary
- introduce category, priority and due date fields in Task entity
- bump DB version
- extend layouts to capture and display new metadata
- add category filtering and spinners in activity
- display due date and category in task list

## Testing
- `./gradlew assembleDebug` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_6859dcab487c8324ad3543958a09feb0