### PR TITLE
Fix missing import in BoardRepository

### DIFF
--- a/app/src/main/java/com/example/holamundo/trello/BoardRepository.java
+++ b/app/src/main/java/com/example/holamundo/trello/BoardRepository.java
@@ -2,6 +2,8 @@ package com.example.holamundo.trello;
 
 import android.content.Context;
 
+import com.example.holamundo.todo.AppDatabase;
+
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;


### PR DESCRIPTION
## Summary
- fix missing `AppDatabase` import in `BoardRepository`

## Testing
- `gradle wrapper` *(fails: Could not resolve dependencies)*
- `./gradlew assembleDebug` *(fails: gradle-wrapper.jar missing)*

------
https://chatgpt.com/codex/tasks/task_e_685a2a0c6ab08324a8b2fb4e26466250