### PR TITLE
Fix stable ID handling in board list

### DIFF
--- a/app/src/main/java/com/example/holamundo/trello/BoardAdapter.java
+++ b/app/src/main/java/com/example/holamundo/trello/BoardAdapter.java
@@ -19,6 +19,15 @@ import java.util.List;
  * Adaptador para mostrar tableros en un RecyclerView.
  */
 public class BoardAdapter extends RecyclerView.Adapter<BoardAdapter.BoardViewHolder> {
+    /**
+     * Constructor que habilita los IDs estables desde el inicio para evitar
+     * cambiarlos una vez el adaptador se haya registrado en el RecyclerView.
+     */
+    public BoardAdapter() {
+        // Habilitamos los IDs estables antes de que se registren observadores
+        // tal y como recomienda la documentación de RecyclerView.
+        setHasStableIds(true);
+    }
     private final List<Board> boards = new ArrayList<>();
     private BoardActionsListener listener;
 

--- a/app/src/main/java/com/example/holamundo/trello/BoardListActivity.java
+++ b/app/src/main/java/com/example/holamundo/trello/BoardListActivity.java
@@ -30,13 +30,14 @@ public class BoardListActivity extends AppCompatActivity implements BoardAdapter
         setTitle(R.string.title_boards);
 
         repository = new BoardRepository(this);
+        // El adaptador se encarga de habilitar los IDs estables en su constructor
+        // para evitar llamar a setHasStableIds una vez registrado.
         adapter = new BoardAdapter();
         adapter.setListener(this);
 
         RecyclerView recyclerView = findViewById(R.id.recycler_boards);
         recyclerView.setLayoutManager(new LinearLayoutManager(this));
         recyclerView.setAdapter(adapter);
-        adapter.setHasStableIds(true);
 
         FloatingActionButton fab = findViewById(R.id.fab_add_board);
         fab.setOnClickListener(v -> showAddDialog());


### PR DESCRIPTION
## Summary
- set stable IDs in the `BoardAdapter` constructor
- remove late call to `setHasStableIds(true)` from `BoardListActivity`
- add explanatory comments

## Testing
- `./gradlew test` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_685a311b226083249f0c10291392ce1e